### PR TITLE
Checkbox: Refactoring to use hidden native checkbox for more compliant form behavior

### DIFF
--- a/docs/components/components/CheckboxDocumentation.js
+++ b/docs/components/components/CheckboxDocumentation.js
@@ -5,7 +5,7 @@ import {propertyNameStyle, propertyDescriptionStyle} from '../../style';
 
 const basicCodeExample = `<Checkbox
   checked={this.state.isChecked}
-  onClick={() => {
+  onChange={() => {
     this.setState({ isChecked: !this.state.isChecked })
   }} >
 </Checkbox>`;
@@ -16,10 +16,13 @@ const radiumStylesCodeExample = `
   checked
   style={{
     base: { width: 100, height: 100 },
-    checked: { background: "green" }
+    customCheckbox: {
+      checked: { background: "green" }
+    }
   }}>
 </Checkbox>`;
 const checkedExample = `<Checkbox checked></Checkbox>`;
+const uncontrolledExample = `<Checkbox defaultChecked={true}></Checkbox>`;
 const emptyExample = `<Checkbox></Checkbox>`;
 
 export default class CheckboxComponent extends Component {
@@ -113,7 +116,7 @@ export default class CheckboxComponent extends Component {
 
         </tbody></table>
 
-        <p>Any other property valid for a HTML button like <b>className</b>, <b>onClick</b>, …</p>
+        <p>Any other property valid for a HTML checkbox like <b>className</b>, …</p>
 
 
         <h3>More Examples</h3>
@@ -129,7 +132,8 @@ export default class CheckboxComponent extends Component {
             <Checkbox 
               checked
               disabled
-              onClick={() => {console.log("DED")}}></Checkbox>
+              onChange={() => console.log("yolo")}>
+            </Checkbox>
             <Code value={ disabledCheckedExample } />
           </li>
           <li>
@@ -143,12 +147,19 @@ export default class CheckboxComponent extends Component {
             <Code value={ emptyExample } />
           </li>
           <li>
+            <h4>Uncontrolled Component</h4>
+            <Checkbox defaultChecked={true}></Checkbox>
+            <Code value={ uncontrolledExample } />
+          </li>
+          <li>
             <h4>Override default Radium styles</h4>
             <Checkbox
               checked
               style={{
                 base: { width: 100, height: 100 },
-                checked: { background: "green" }
+                customCheckbox: {
+                  checked: { background: "green" }
+                }
               }}>
             </Checkbox>
             <Code value={ radiumStylesCodeExample } />

--- a/src/__tests__/Checkbox-test.js
+++ b/src/__tests__/Checkbox-test.js
@@ -22,42 +22,87 @@ describe("Checkbox", () => {
 		expect(checkboxNode.className).toBeDefined();
 	});
 
-	it("should be able to bind to onClick", () => {
+	it("should be able to bind to onChange", () => {
 		let wasClicked = false;
 		const myCheckboxClass = "my-checkbox-class";
 
-		// Render a button with an onClick handler
+		// Render with an onClick handler
 		const checkbox = TestUtils.renderIntoDocument(
 			<Checkbox
 				className={myCheckboxClass}
-				onClick={ () => wasClicked = true }>
+				onChange={ () => wasClicked = true }>
 			</Checkbox>
 		);
 
-		// Simulate a click
-		TestUtils.Simulate.click(TestUtils.findRenderedDOMComponentWithClass(checkbox, myCheckboxClass));
+		// Simulate a change
+		TestUtils.Simulate.change(TestUtils.findRenderedDOMComponentWithClass(checkbox, myCheckboxClass));
 
 		expect(wasClicked).toBeTruthy();
 	});
 
-	it("should supress onClick listener if disabled", () => {
+	it("should supress onChange listener if disabled", () => {
 		let wasClicked = false;
 		const myCheckboxClass = "my-checkbox-class";
 
-		// Render a button with an onClick handler
+		// Render with an onChange handler
 		const checkbox = TestUtils.renderIntoDocument(
 			<Checkbox
 				disabled
 				className={myCheckboxClass}
-				onClick={() => {
+				onChange={() => {
 					wasClicked = true;
 				}}>
 			</Checkbox>
 		);
 
-		// Simulate a click
-		TestUtils.Simulate.click(TestUtils.findRenderedDOMComponentWithClass(checkbox, myCheckboxClass));
+		// Simulate a change
+		TestUtils.Simulate.change(TestUtils.findRenderedDOMComponentWithClass(checkbox, myCheckboxClass));
 
 		expect(wasClicked).toBeFalsy();
 	});
+
+	it("should apply `checked` attribute to invisible input element if passed down as prop", function() {
+		const checkbox = TestUtils.renderIntoDocument(
+			<Checkbox checked></Checkbox>
+		);
+
+		const hiddenInput = TestUtils.findRenderedDOMComponentWithTag(checkbox, "input");
+		const checked = hiddenInput.getAttribute("checked");
+
+		expect(checked).not.toBeNull();
+	});
+
+	it("should not apply `checked` attribute to invisible input element if it is not specified as prop", function() {
+		const checkbox = TestUtils.renderIntoDocument(
+			<Checkbox></Checkbox>
+		);
+
+		const hiddenInput = TestUtils.findRenderedDOMComponentWithTag(checkbox, "input");
+		const checked = hiddenInput.getAttribute("checked");
+
+		expect(checked).toBeNull();
+	});
+
+	it("should set `checked` attribute on invisible input element if `defaultChecked` prop is true", function() {
+		const checkbox = TestUtils.renderIntoDocument(
+			<Checkbox defaultChecked={true}></Checkbox>
+		);
+
+		const hiddenInput = TestUtils.findRenderedDOMComponentWithTag(checkbox, "input");
+		const checked = hiddenInput.getAttribute("checked");
+
+		expect(checked).not.toBeNull();
+	});
+
+	it("should not set `checked` attribute on invisible input element if `defaultChecked` prop is false", function() {
+		const checkbox = TestUtils.renderIntoDocument(
+			<Checkbox defaultChecked={false}></Checkbox>
+		);
+
+		const hiddenInput = TestUtils.findRenderedDOMComponentWithTag(checkbox, "input");
+		const checked = hiddenInput.getAttribute("checked");
+
+		expect(checked).toBeNull();
+	});
+
 });

--- a/src/components/Checkbox/styles.js
+++ b/src/components/Checkbox/styles.js
@@ -6,31 +6,59 @@ const DEFAULT_CHECKBOX_SIZE = 25;
 export default {
 	base: {
 		height: DEFAULT_CHECKBOX_SIZE,
-		width: DEFAULT_CHECKBOX_SIZE,
-		borderRadius: 3,
-		borderStyle: "solid",
-		borderColor: stColorPalette.stSilver,
-		borderWidth: 2,
-		cursor: "pointer",
-		transition: "all 0.20s",
-		":focus": {
-			borderColor: colorLib(colors.primary).lighten(0.25).hexString(),
-			outline: 0
+		width: DEFAULT_CHECKBOX_SIZE
+	},
+	contentWrapper: {
+		position: "relative",
+		width: "100%",
+		height: "100%"
+	},
+	// Styles for the hidden checkbox <input> element
+	baseHiddenInput: {
+		base: {
+			position: "absolute",
+			opacity: 0,
+			height: "100%",
+			width: "100%",
+			cursor: "pointer",
+			zIndex: 2
+		},
+		disabled: {
+			cursor: "not-allowed"
 		}
 	},
-	checked: {
-		background: colors.primary,
-		borderColor: colors.primary,
-		":focus": {
-			borderColor: colors.primary
-		}
-	},
-	disabled: {
-		background: colors.disabledBg,
-		borderColor: stColorPalette.stSilver,
-		cursor: "not-allowed",
-		":focus": {
-			borderColor: stColorPalette.stSilver
+	// Styles for custom checkbox element
+	customCheckbox: {
+		base: {
+			height: "100%",
+			width: "100%",
+			position: "absolute",
+			borderRadius: 3,
+			borderStyle: "solid",
+			borderColor: stColorPalette.stSilver,
+			borderWidth: 2,
+			cursor: "pointer",
+			transition: "all 0.20s",
+			zIndex: 1,
+			":focus": {
+				borderColor: colorLib(colors.primary).lighten(0.25).hexString(),
+				outline: 0
+			}
+		},
+		checked: {
+			background: colors.primary,
+			borderColor: colors.primary,
+			":focus": {
+				borderColor: colors.primary
+			}
+		},
+		disabled: {
+			background: colors.disabledBg,
+			borderColor: stColorPalette.stSilver,
+			cursor: "not-allowed",
+			":focus": {
+				borderColor: stColorPalette.stSilver
+			}
 		}
 	},
 	// Styles for checkbox content container


### PR DESCRIPTION
This PR refactors the Checkbox component to have a hidden input HTML element with type=checkbox that always matches the state of the checkbox so that this component can be used properly inside HTML forms
