### PR TITLE
 Radium is in devDependecies. npm would not install it

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,6 @@
   "license": "MIT",
   "dependencies": {
     "exenv": "^1.2.0",
-	"radium": "^0.16.5"
+    "radium": "^0.16.5"
   }
 }


### PR DESCRIPTION
unless it is under dependecies
