### PR TITLE
make Tab background transparent so that color only has to be set on tabBar

### DIFF
--- a/docs/components/components/TabsDocumentation.js
+++ b/docs/components/components/TabsDocumentation.js
@@ -24,6 +24,23 @@ const noLabelExample = `<Tabs>
   </Tab>
 </Tabs>`;
 
+const radiumStylesCodeExample = `<Tabs style={{
+	tabContainer: {
+		background: "black"
+	},
+	tabBar: {
+		background: "black",
+		paddingLeft: 120
+	}
+}}>
+  <Tab label="First Tab">
+    First Tab
+  </Tab>
+  <Tab label="Second Tab">
+    Second Tab
+  </Tab>
+</Tabs>`;
+
 export default class TabsDocumentation extends Component {
 	render() {
 		return (
@@ -72,8 +89,8 @@ export default class TabsDocumentation extends Component {
 					<br />
 					<b>default:</b> 0
 				</p>
-				<p>Specify initial visible tab index. Initial selected index is set by default to 0. 
-				If initialSelectedIndex is set but larger than the total amount of specified tabs, 
+				<p>Specify initial visible tab index. Initial selected index is set by default to 0.
+				If initialSelectedIndex is set but larger than the total amount of specified tabs,
 				initialSelectedIndex will revert back to default.</p>
 				</td>
 			</tr>
@@ -111,6 +128,31 @@ export default class TabsDocumentation extends Component {
 			</tr>
 
 			</tbody></table>
+
+			<h3>More Examples</h3>
+
+      <ul>
+        <li>
+          <h4>Override Radium Styles</h4>
+          <Tabs style={{
+						tabContainer: {
+							background: "black"
+						},
+						tabBar: {
+							background: "black",
+							paddingLeft: 120
+						}
+					}}>
+					  <Tab label="First Tab">
+					    First Tab
+					  </Tab>
+					  <Tab label="Second Tab">
+					    Second Tab
+					  </Tab>
+					</Tabs>
+          <Code value={ radiumStylesCodeExample } style={ {marginTop: 20} } />
+        </li>
+      </ul>
 
 		</div>)
 	}

--- a/src/components/Tabs/styles.js
+++ b/src/components/Tabs/styles.js
@@ -5,7 +5,8 @@ export default function() {
 		base: {
 			height: "50px",
 			padding: "0 20px",
-			lineHeight: "50px"
+			lineHeight: "50px",
+			background: "transparent"
 		},
 		active: {
 			transition: "color 0.2s",


### PR DESCRIPTION
Making the background for the `<Tab/>` component transparent so that individual tabs take on the color of whatever the user species for the tab bar background color. I need this extensibility because the Pricing page has a very custom color needed for the tabs, and i dont want to have to refactor this to specify an inline style for each individual tab

![tab-background-transparent](https://cloud.githubusercontent.com/assets/437318/13410867/0643993a-df08-11e5-9a3f-fa52d12358a0.gif)
