### PR TITLE
implementing onChange() prop for Tabs

### DIFF
--- a/docs/components/components/TabsDocumentation.js
+++ b/docs/components/components/TabsDocumentation.js
@@ -97,6 +97,23 @@ export default class TabsDocumentation extends Component {
 
 			<tr>
 				<td style={ propertyNameStyle }>
+				onChange(int newTabIndex newTabIndex)
+				</td>
+			</tr>
+			<tr>
+				<td style={ propertyDescriptionStyle }>
+				<p >
+					<i>onChange(number newTabIndex)</i>
+					<br />
+					<b>default:</b> no-op function
+				</p>
+				<p>Callback function that is triggered when a new tab is selected. The function is invoked with
+				the index of the newly-selected tab.</p>
+				</td>
+			</tr>
+
+			<tr>
+				<td style={ propertyNameStyle }>
 				label
 				</td>
 			</tr>

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "babel-jest": "^5.3.0",
     "babel-loader": "^5.3.3",
     "babel-plugin-react-transform": "^1.1.1",
-    "color": "^0.11.1",
     "eslint": "^1.10.3",
     "eslint-config-airbnb": "1.0.0",
     "eslint-plugin-mocha": "^1.1.0",
@@ -52,7 +51,6 @@
     "jscs": "^2.6.0",
     "react": "^0.14.3",
     "react-addons-test-utils": "^0.14.3",
-    "react-dom": "^0.14.3",
     "react-transform-catch-errors": "^1.0.0",
     "react-transform-hmr": "^1.0.1",
     "redbox-react": "^1.2.0",
@@ -79,7 +77,9 @@
   },
   "license": "MIT",
   "dependencies": {
+    "color": "^0.11.1",
     "exenv": "^1.2.0",
-    "radium": "^0.16.5"
+    "radium": "^0.16.5",
+    "react-dom": "^0.14.3"
   }
 }

--- a/src/__tests__/Tabs-test.js
+++ b/src/__tests__/Tabs-test.js
@@ -95,4 +95,26 @@ describe("Tabs", () => {
 		expect(tabsNode.hasAttribute("label")).toBe(true);
 		expect(tabsNode.children[0].children[0].innerHTML).toBe("Account Settings");
 	});
+
+	it("should trigger `onChange()` prop when un-selected Tab is clicked on and selected", () => {
+		let selectedIndex = null;
+
+		const tabs = TestUtils.renderIntoDocument(
+			<Tabs
+				initialSelectedIndex={0}
+				className="tabs"
+				label="Account Settings"
+				onChange={(newIndex) => {
+					selectedIndex = newIndex;
+				}}>
+				<Tab className="firstTab"></Tab>
+				<Tab className="secondTab"></Tab>
+			</Tabs>
+		);
+		// Simulate a click on second tab
+		TestUtils.Simulate.click(TestUtils.findRenderedDOMComponentWithClass(tabs, "secondTab"));
+
+		// Assert
+		expect(selectedIndex).toEqual(1);
+	});
 });

--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -47,6 +47,7 @@ export default class Tabs extends Component {
 	_handleTabSelection(event, tab) {
 		const tabIndex = tab.props.tabIndex;
 		if (this.state.selectedIndex !== tabIndex) {
+			this.props.onChange(tabIndex);
 			this.setState({
 				selectedIndex: tabIndex
 			});
@@ -67,7 +68,7 @@ export default class Tabs extends Component {
 						selected: this._getSelected(tab, index)
 					}, tab.props.children) : undefined
 				);
-				
+
 				return React.cloneElement(tab, {
 					key: index,
 					selected: this._getSelected(tab, index),
@@ -132,4 +133,8 @@ Tabs.propTypes = {
 	onChange: PropTypes.func,
 	style: PropTypes.object,
 	value: PropTypes.any
+};
+
+Tabs.defaultProps = {
+	onChange: function() {}
 };


### PR DESCRIPTION
I saw that in the Tab component we had a `onChange()` prop, but I saw that it was not implemented.

This PR implements it (I need it for the payments app)
