### PR TITLE
Update docs, tests for behavior of Radio callback

### DIFF
--- a/docs/components/components/RadioButtonDocumentation.js
+++ b/docs/components/components/RadioButtonDocumentation.js
@@ -151,8 +151,13 @@ export default class RadioButtonDocumentation extends Component {
           <td style={ propertyDescriptionStyle }>
             <p >
               <i>Function</i>
+              <br />
+              <i>onChange(Event event, String value)</i>
+              <br />
+              <b>default:</b> no-op function
             </p>
-            <p>Callback function that is fired when a radio button has been clicked.</p>
+            <p>Callback function that is fired when a radio button has been clicked. The callback receives the event
+            and the `value` of the currently-selected radio button. </p>
           </td>
         </tr>
 

--- a/src/__tests__/RadioButton-test.js
+++ b/src/__tests__/RadioButton-test.js
@@ -55,6 +55,27 @@ describe("RadioButton", () => {
 		expect(wasClicked).toBeTruthy();
 	});
 
+	it("should call onSelect with the event and value", () => {
+		const handler = jest.genMockFunction();
+
+		// Render a RadioButtonGroup with an onSelect handler
+		const radioButtonGroup = TestUtils.renderIntoDocument(
+			<RadioButtonGroup onSelect={ handler }>
+				<RadioButton value="test1" label="Test2"/>
+				<RadioButton value="test2" label="Test2" className="test2"/>
+			</RadioButtonGroup>
+		);
+
+		// Simulate a click
+		const el = TestUtils.scryRenderedDOMComponentsWithTag(radioButtonGroup, "input")[1]
+		TestUtils.Simulate.click(el);
+		const calledWith = handler.mock.calls[0]
+		
+		// make sure called with a synthetic event
+		expect(calledWith[0].nativeEvent).toBeDefined()
+		expect(calledWith[1]).toBe("test2");
+	});
+
 	it("should surpress onSelect listener if disabled", () => {
 		let wasClicked = false;
 
@@ -87,4 +108,5 @@ describe("RadioButton", () => {
 
 		expect(wasClicked).toBeTruthy();
 	});
+
 });


### PR DESCRIPTION
The value of the selected RadioButton is passed as the second
argument of the RadioButtonGroup callback. Added this info
to the docs and tests.
