### PR TITLE
remove dupl decl from raidio btn style

### DIFF
--- a/src/components/RadioButton/styles.js
+++ b/src/components/RadioButton/styles.js
@@ -16,7 +16,6 @@ export default function() {
 			display: "table-cell",
 			height: DEFAULT_RADIO_BUTTON_SIZE,
 			width: DEFAULT_RADIO_BUTTON_SIZE,
-			lineHeight: "initial",
 			borderRadius: "50%",
 			borderStyle: "solid",
 			borderColor: stColorPalette.stSilver,


### PR DESCRIPTION
Duplicate `lineHeight` rule in radio button was causing this to break on IE
"Multiple definitions of a property not allowed in strict mode"
