### PR TITLE
Remove duplicate `backgroundColor` property

### DIFF
--- a/src/components/SelectBox/styles.js
+++ b/src/components/SelectBox/styles.js
@@ -65,7 +65,6 @@ export default {
 	/* Option Styles */
 	optionList: {
 		position: "absolute",
-		backgroundColor: stColorPalette.stWhite,
 		overflow: "auto",
 		width: "100%",
 		left: 0,


### PR DESCRIPTION
Fix for IE, which complains about duplicate attributes in strict mode

Pretty sure this is the last PR like this
