### PR TITLE
[BE-240] remove growler content from DOM

### DIFF
--- a/src/components/Growler/Growler.js
+++ b/src/components/Growler/Growler.js
@@ -67,6 +67,7 @@ export default class Growler extends Component {
 
 		// Remove growler content from DOM
 		if (this._growlerContentElement) {
+			ReactDOM.unmountComponentAtNode(this._growlerContentElement);
 			document.body.removeChild(this._growlerContentElement);
 		}
 


### PR DESCRIPTION
Growler component was not being unmounted from DOM, and more and more growlers would be added to the page as UI notifications were received
![growler_content_wrapper](https://cloud.githubusercontent.com/assets/8314270/17221097/405103f0-54c0-11e6-879c-94246f73c999.gif)
Now the growler component unmounts as expected
![growler_content_wrapper_removed](https://cloud.githubusercontent.com/assets/8314270/17221100/4391338c-54c0-11e6-8239-6f425a0db1b3.gif)
