### PR TITLE
Add selectbox dropdown transition time

### DIFF
--- a/docs/components/components/SelectBoxDocumentation.js
+++ b/docs/components/components/SelectBoxDocumentation.js
@@ -48,6 +48,15 @@ const sizeOptionCodeExample = `<SelectBox
   <SelectBoxOption value="5.5-square" displayLabel="5.5' Square Table"></SelectBoxOption>
   <SelectBoxOption value="6-square" displayLabel="6' Square Table"></SelectBoxOption>
 </SelectBox>`;
+const transitionDurationCodeExample = `<SelectBox
+  value={this.state.transitionDurationSelectedValue}
+  transitionDuration={0.8}
+  defaultText="Select a Table Type..."
+  onChange={(v) => { this.setState({transitionDurationSelectedValue: v}) }}>
+  <SelectBoxOption value="round" displayLabel="Round"></SelectBoxOption>
+  <SelectBoxOption value="rectangle" displayLabel="Rectangle"></SelectBoxOption>
+  <SelectBoxOption value="square" displayLabel="Square"></SelectBoxOption>
+</SelectBox>`;
 const radiumStylesCodeExample = `<SelectBox
   value={this.state.overrideRadiumValue}
   style={{base: { width: 150 }}}
@@ -184,6 +193,20 @@ export default class SelectBoxDocumentation extends Component {
 
         <tr>
           <td style={ propertyNameStyle }>
+            transitionDuration
+          </td>
+        </tr>
+        <tr>
+          <td style={ propertyDescriptionStyle }>
+            <i>Number</i>
+            <br />
+            <b>default:</b> null
+            <p>The duration of the dropdown transition in seconds</p>
+          </td>
+        </tr>           
+
+        <tr>
+          <td style={ propertyNameStyle }>
             style
           </td>
         </tr>
@@ -196,7 +219,7 @@ export default class SelectBoxDocumentation extends Component {
             </p>
             <p>Radium-based inline-style</p>
           </td>
-        </tr>
+        </tr>     
 
       </tbody></table>
 
@@ -301,6 +324,19 @@ export default class SelectBoxDocumentation extends Component {
           </SelectBox>
           <Code value={ sizeOptionCodeExample } style={ {marginTop: 20} } />
         </li>
+        <li>
+          <h4><i>transitionDuration</i> property specified</h4>
+          <SelectBox
+            value={this.state.transitionDurationSelectedValue}
+            transitionDuration={0.8}
+            defaultText="Select a Table Type..."
+            onChange={(v) => { this.setState({transitionDurationSelectedValue: v}) }}>
+            <SelectBoxOption value="round" displayLabel="Round"></SelectBoxOption>
+            <SelectBoxOption value="rectangle" displayLabel="Rectangle"></SelectBoxOption>
+            <SelectBoxOption value="square" displayLabel="Square"></SelectBoxOption>
+          </SelectBox>
+          <Code value={ transitionDurationCodeExample } style={ {marginTop: 20} } />
+        </li>        
         <li>
           <h4>Override Radium Styles</h4>
           <SelectBox

--- a/src/__tests__/tests/SelectBox-test.js
+++ b/src/__tests__/tests/SelectBox-test.js
@@ -122,4 +122,24 @@ describe("SelectBox", () => {
 		// Assert
 		expect(newOptionValue).toBeNull();
 	});
+
+	pit("does change the dropdown transformation duration when a transformationDuration prop is specified", function() {
+		return new Promise((resolve) => {
+
+			const selectBox = TestUtils.renderIntoDocument(
+				<SelectBox value="rectangle" transitionDuration={0.8} onTransitionEnd={(e) => {
+					expect(e.elapsedTime).toBe(0.8);
+					resolve();
+				}}>
+					<SelectBoxOption value="round"></SelectBoxOption>
+					<SelectBoxOption className="rectangle-option" value="rectangle"></SelectBoxOption>
+					<SelectBoxOption value="square"></SelectBoxOption>
+				</SelectBox>
+			);
+
+			// Open menu by simulating click
+			const selectBoxNode = TestUtils.findRenderedDOMComponentWithTag(selectBox, "select");
+			TestUtils.Simulate.focus(selectBoxNode);
+		});
+	});
 });

--- a/src/__tests__/tests/SelectBox-test.js
+++ b/src/__tests__/tests/SelectBox-test.js
@@ -122,24 +122,4 @@ describe("SelectBox", () => {
 		// Assert
 		expect(newOptionValue).toBeNull();
 	});
-
-	pit("does change the dropdown transformation duration when a transformationDuration prop is specified", function() {
-		return new Promise((resolve) => {
-
-			const selectBox = TestUtils.renderIntoDocument(
-				<SelectBox value="rectangle" transitionDuration={0.8} onTransitionEnd={(e) => {
-					expect(e.elapsedTime).toBe(0.8);
-					resolve();
-				}}>
-					<SelectBoxOption value="round"></SelectBoxOption>
-					<SelectBoxOption className="rectangle-option" value="rectangle"></SelectBoxOption>
-					<SelectBoxOption value="square"></SelectBoxOption>
-				</SelectBox>
-			);
-
-			// Open menu by simulating click
-			const selectBoxNode = TestUtils.findRenderedDOMComponentWithTag(selectBox, "select");
-			TestUtils.Simulate.focus(selectBoxNode);
-		});
-	});
 });

--- a/src/components/SelectBox/SelectBox.js
+++ b/src/components/SelectBox/SelectBox.js
@@ -89,11 +89,11 @@ export default class SelectBox extends Component {
 			<div
 				style={[
 					styles.optionList,
+					this.props.transitionDuration && transitionDurationFromProp,
 					this.state.isOptionListOpen && openStyles,
 					this.state.isOptionListOpen && this.props.size && maxHeightFromSizeProp,
 					!this.state.isOptionListOpen && closedStyles,
-					this.props.style && this.props.style.optionList,
-					this.props.style && this.props.transitionDuration && transitionDurationFromProp
+					this.props.style && this.props.style.optionList
 				]}>
 				{options}
 			</div>

--- a/src/components/SelectBox/SelectBox.js
+++ b/src/components/SelectBox/SelectBox.js
@@ -64,8 +64,14 @@ export default class SelectBox extends Component {
 		const openStyles = this.props.style && this.props.style.optionList && this.props.style.optionList.open || styles.optionList.open;
 		const closedStyles = this.props.style && this.props.style.optionList && this.props.style.optionList.closed || styles.optionList.closed;
 		let maxHeightFromSizeProp = {};
+		
 		if (this.props.size) {
 			maxHeightFromSizeProp.maxHeight = this.props.size * styles.option.minHeight;
+		}
+
+		let transitionDurationFromProp = {};
+		if (this.props.transitionDuration) {
+			transitionDurationFromProp.transition = `max-height ${this.props.transitionDuration}s ease-in, opacity 0.2s ease-out`;
 		}
 
 		let options = null;
@@ -86,7 +92,8 @@ export default class SelectBox extends Component {
 					this.state.isOptionListOpen && openStyles,
 					this.state.isOptionListOpen && this.props.size && maxHeightFromSizeProp,
 					!this.state.isOptionListOpen && closedStyles,
-					this.props.style && this.props.style.optionList
+					this.props.style && this.props.style.optionList,
+					this.props.style && this.props.transitionDuration && transitionDurationFromProp
 				]}>
 				{options}
 			</div>
@@ -226,7 +233,8 @@ SelectBox.propTypes = {
 	size: PropTypes.number,
 	onChange: PropTypes.func,
 	required: PropTypes.bool,
-	className: PropTypes.string
+	className: PropTypes.string,
+	transitionDuration: PropTypes.number
 };
 
 SelectBox.defaultProps = {

--- a/src/components/SelectBox/SelectBox.js
+++ b/src/components/SelectBox/SelectBox.js
@@ -69,9 +69,9 @@ export default class SelectBox extends Component {
 			maxHeightFromSizeProp.maxHeight = this.props.size * styles.option.minHeight;
 		}
 
-		let transitionDurationFromProp = {};
+		let transitionStyles = {};
 		if (this.props.transitionDuration) {
-			transitionDurationFromProp.transition = `max-height ${this.props.transitionDuration}s ease-in, opacity 0.2s ease-out`;
+			transitionStyles.transition = `max-height ${this.props.transitionDuration}s ease-in, opacity 0.2s ease-out`;
 		}
 
 		let options = null;
@@ -89,7 +89,7 @@ export default class SelectBox extends Component {
 			<div
 				style={[
 					styles.optionList,
-					this.props.transitionDuration && transitionDurationFromProp,
+					this.props.transitionDuration && transitionStyles,
 					this.state.isOptionListOpen && openStyles,
 					this.state.isOptionListOpen && this.props.size && maxHeightFromSizeProp,
 					!this.state.isOptionListOpen && closedStyles,


### PR DESCRIPTION
Add an optional prop to the SelectBox component to change the duration of the dropdown menu transition.

Default transition duration of 0.4s
![transitionduration default](https://cloud.githubusercontent.com/assets/6211086/18877020/d98b1c1e-8499-11e6-8921-9eca52a93d4d.gif)

Transition duration of 1.5s
![transitionduration with prop specified](https://cloud.githubusercontent.com/assets/6211086/18877057/f7f74c2c-8499-11e6-8c99-f61e7273eff2.gif)

