### PR TITLE
fix longhand/shorthand warning when using padding/border

### DIFF
--- a/src/components/Button/styles.js
+++ b/src/components/Button/styles.js
@@ -27,7 +27,10 @@ export default function({ theme, shape }) {
 		base: {
 			backgroundColor: btnBackgroundColor,
 			color: colors.white,
-			border: 0,
+			borderLeft: 0,
+			borderRight: 0,
+			borderTop: 0,
+			borderBottom: 0,
 			outline: 0,
 			userSelect: "none",
 			cursor: "pointer",

--- a/src/components/Card/styles.js
+++ b/src/components/Card/styles.js
@@ -1,6 +1,9 @@
 export default {
 	base: {
-		padding: 40,
+		paddingTop: 40,
+		paddingBottom: 40,
+		paddingLeft: 40,
+		paddingRight: 40,
 		borderRadius: 2,
 		backgroundColor: "#fff",
 		boxShadow: "0 1px 1px rgba(0, 0, 0, 0.2)",

--- a/src/components/RadioButton/styles.js
+++ b/src/components/RadioButton/styles.js
@@ -57,7 +57,10 @@ export default function() {
 		// styles for the radio button label
 		labelWrapper: {
 			display: "table-cell",
-			padding: "0px 5px"
+			paddingTop: "0px",
+			paddingBottom: "0px",
+			paddingLeft: "5px",
+			paddingRight: "5px"
 		}
 	};
 }

--- a/src/components/SelectBox/SelectBoxOption.js
+++ b/src/components/SelectBox/SelectBoxOption.js
@@ -22,7 +22,7 @@ export default class SelectBoxOption extends Component {
 	 * Update the childProps based on the updated properties passed to the text box.
 	 */
 	componentWillReceiveProps(properties) {
-		const { style, ...childProps } = properties; // eslint-disable-line no-unused-vars
+		const { style, displayLabel, ...childProps } = properties; // eslint-disable-line no-unused-vars
 		this._childProps = childProps;
 	}
 

--- a/src/components/SelectBox/styles.js
+++ b/src/components/SelectBox/styles.js
@@ -12,7 +12,10 @@ export default {
 	},
 	/* Main Box Styles */
 	selectBox: {
-		padding: PADDING,
+		paddingLeft: PADDING,
+		paddingRight: PADDING,
+		paddingTop: PADDING,
+		paddingBottom: PADDING,
 		width: "100%",
 		height: "100%",
 		transition: "border-color .3s",
@@ -89,7 +92,10 @@ export default {
 	option: {
 		minHeight: 35,
 		width: "100%",
-		padding: PADDING,
+		paddingLeft: PADDING,
+		paddingRight: PADDING,
+		paddingTop: PADDING,
+		paddingBottom: PADDING,
 		userSelect: "none",
 		transition: "background .4s ease-in-out",
 		enabled: {

--- a/src/components/Tabs/styles.js
+++ b/src/components/Tabs/styles.js
@@ -4,7 +4,10 @@ export default function() {
 	return {
 		base: {
 			height: "50px",
-			padding: "0 20px",
+			paddingTop: "0px",
+			paddingBottom: "0px",
+			paddingLeft: "20px",
+			paddingRight: "20px",
 			lineHeight: "50px",
 			backgroundColor: "transparent"
 		},
@@ -20,19 +23,28 @@ export default function() {
 		},
 		tabContainer: {
 			backgroundColor: colors.colorMain,
-			padding: "0 46px"
+			paddingTop: "0px",
+			paddingBottom: "0px",
+			paddingLeft: "46px",
+			paddingRight: "46px"
 		},
 		header: {
 			backgroundColor: colors.colorMain,
 			color: colors.white,
 			fontSize: "24px",
-			padding: "20px 0"
+			paddingTop: "20px",
+			paddingBottom: "20px",
+			paddingLeft: "0px",
+			paddingRight: "0px"
 		},
 		tabBar: {
 			backgroundColor: colors.colorMain
 		},
 		tabContent: {
-			margin: "0 46px"
+			marginTop: "0px",
+			marginBotton: "0px",
+			marginLeft: "46px",
+			marginRight: "46px"
 		}
 	}
 }

--- a/src/components/TextBox/styles.js
+++ b/src/components/TextBox/styles.js
@@ -3,7 +3,10 @@ import { default as colors, stColorPalette } from "../../shared-styles/colors";
 export default {
 	base: {
 		color: stColorPalette.stDarkGray,
-		padding: 10,
+		paddingLeft: 10,
+		paddingRight: 10,
+		paddingTop: 10,
+		paddingBottom: 10,
 		transition: "all .2s",
 		borderColor: stColorPalette.stSilver,
 		borderStyle: "solid",


### PR DESCRIPTION
<img width="1208" alt="screen shot 2017-01-19 at 3 37 29 pm" src="https://cloud.githubusercontent.com/assets/3675602/22124292/395b9944-de5d-11e6-9308-94f83d36d709.png">

to prevent warning like this
